### PR TITLE
Fix segment boundary calculation for DXF recipes

### DIFF
--- a/utils/dxf_parser.py
+++ b/utils/dxf_parser.py
@@ -194,16 +194,15 @@ def generate_recipe_from_dxf(file_path, resolution=1.0, use_interpolation=True, 
             y *= scale
             if mirror:
                 x = -x
-            
+
             display_path.append((x, y))
             movement_path.append((x, y, z_height))
-            
-            # Mark segment boundaries (end of each original line)
-            if i > 0:
-                segment_boundaries.append(len(movement_vertices)-1)
-        
+
         display_paths.append(display_path)
         movement_vertices.extend(movement_path)
+
+        # Mark segment boundary at the end of each path
+        segment_boundaries.append(len(movement_vertices) - 1)
     
     return {
         'display': {


### PR DESCRIPTION
## Summary
- record segment boundaries once per path in `generate_recipe_from_dxf`

## Testing
- `PYENV_VERSION=3.11.12 python -m py_compile utils/dxf_parser.py`
- `PYENV_VERSION=3.11.12 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8b5116e08329a3dac800b04e3d7d